### PR TITLE
update assertion as content type can also return charset

### DIFF
--- a/namutil/hz.py
+++ b/namutil/hz.py
@@ -93,7 +93,7 @@ def read_google_doc(*args, **kwargs):
     except ImportError: import urllib2 as request
     export_url = get_google_doc_export_url(*args)
     resp = request.urlopen(export_url)
-    assert resp.headers['content-type'] == 'text/tab-separated-values', "bad content type '{}'; ensure that sheet is published: {}".format(resp.headers['content-type'], repr(args))
+    assert 'text/tab-separated-values' in resp.headers['content-type'], "bad content type '{}'; ensure that sheet is published: {}".format(resp.headers['content-type'], repr(args))
     data = resp.read().decode('utf8')
     header, rows = data.split("\n", 1)
     header = header.split("\t")


### PR DESCRIPTION
facing error when getting content type of
`'text/tab-separated-values; charset=utf-8'`
which is still the correct content type however with information of the charset, which doesnt qualify the assertion


temporarily branch is used and deployed as part of https://github.com/namshi/webuy-api/pull/442